### PR TITLE
feat: multi-consumer race fixes + admin send endpoint

### DIFF
--- a/src/weilink/_cli/_hook.py
+++ b/src/weilink/_cli/_hook.py
@@ -108,28 +108,34 @@ def hook_poll(
             pass
         return {"has_messages": False, "count": 0, "context": ""}
 
-    last_ts = _load_last_ts(state_file)
-    if last_ts == 0:
-        last_ts = int((time.time() - _DEFAULT_LOOKBACK_S) * 1000)
+    from weilink._vendor.filelock import FileLock
 
-    now_ms = int(time.time() * 1000)
+    # Serialize concurrent hook-poll invocations (e.g. multiple IDE
+    # instances) so each one sees a consistent last_ts.
+    hook_lock = FileLock(base_path / ".hook.lock")
+    with hook_lock:
+        last_ts = _load_last_ts(state_file)
+        if last_ts == 0:
+            last_ts = int((time.time() - _DEFAULT_LOOKBACK_S) * 1000)
 
-    # Read directly from SQLite store — fast, no network.
-    wl = WeiLink(base_path=base_path, message_store=True)
-    store = wl._message_store
-    if store is None:
-        wl.close()
+        now_ms = int(time.time() * 1000)
+
+        # Read directly from SQLite store — fast, no network.
+        wl = WeiLink(base_path=base_path, message_store=True)
+        store = wl._message_store
+        if store is None:
+            wl.close()
+            _save_last_ts(state_file, now_ms)
+            return {"has_messages": False, "count": 0, "context": ""}
+
+        try:
+            messages = store.query(direction=1, since_ms=last_ts, limit=limit)
+        except Exception:
+            messages = []
+        finally:
+            wl.close()
+
         _save_last_ts(state_file, now_ms)
-        return {"has_messages": False, "count": 0, "context": ""}
-
-    try:
-        messages = store.query(direction=1, since_ms=last_ts, limit=limit)
-    except Exception:
-        messages = []
-    finally:
-        wl.close()
-
-    _save_last_ts(state_file, now_ms)
 
     if not messages:
         return {"has_messages": False, "count": 0, "context": ""}

--- a/src/weilink/admin/admin.html
+++ b/src/weilink/admin/admin.html
@@ -487,6 +487,73 @@ tr:hover td { background: var(--bg-hover); }
   text-align: center;
   flex-shrink: 0;
 }
+.send-area {
+  padding: 10px 20px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+.send-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+.send-row textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  max-height: 80px;
+  min-height: 36px;
+  outline: none;
+  font-family: inherit;
+}
+.send-row textarea:focus { border-color: var(--accent); }
+.send-actions { display: flex; gap: 4px; flex-shrink: 0; }
+.btn-attach {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  cursor: pointer;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+.btn-attach:hover { border-color: var(--accent); color: var(--accent); }
+.btn-send {
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.btn-send:hover { opacity: 0.9; }
+.btn-send:disabled { opacity: 0.5; cursor: not-allowed; }
+.send-attachment {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.send-attachment .remove {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+.send-attachment .remove:hover { color: #e53e3e; }
 
 /* Chat bubbles */
 #msgBubbles {
@@ -752,6 +819,16 @@ tr:hover td { background: var(--bg-hover); }
       <div id="msgBubbles"></div>
       <div class="bubble-empty" id="msgEmpty" style="display:none" data-i18n="messages.no_messages">No messages found</div>
     </div>
+    <div class="send-area" id="msgSendArea">
+      <div id="msgAttachmentPreview"></div>
+      <div class="send-row">
+        <button class="btn-attach" onclick="document.getElementById('msgFileInput').click()" title="Attach file">&#x1F4CE;</button>
+        <textarea id="msgSendInput" rows="1" data-i18n-placeholder="send.placeholder" placeholder="Type a message..."
+                  onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendFromDrawer()}"></textarea>
+        <button class="btn-send" id="msgSendBtn" onclick="sendFromDrawer()" data-i18n="send.send">Send</button>
+      </div>
+      <input type="file" id="msgFileInput" style="display:none" onchange="handleFileAttach(this)" accept="image/*,audio/*,video/*,*/*">
+    </div>
     <div class="drawer-footer" id="msgDrawerFooter"></div>
   </div>
 </div>
@@ -894,6 +971,13 @@ class WeiLinkAPI {
       if (v !== undefined && v !== null && v !== '') qs.set(k, v);
     }
     return this.request(`/api/messages?${qs}`);
+  }
+
+  async sendMessage(payload) {
+    return this.request('/api/send', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
   }
 }
 
@@ -1454,6 +1538,77 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Auto-refresh every 30s
   refreshTimer = setInterval(refreshAll, 30000);
 });
+
+// ============================================================
+// Send message
+// ============================================================
+let _pendingFile = null; // { name, type, data (base64 string) }
+
+function handleFileAttach(input) {
+  const file = input.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    // result is "data:<mime>;base64,<data>" — extract the base64 part
+    const b64 = reader.result.split(',')[1];
+    _pendingFile = { name: file.name, type: file.type, data: b64 };
+    const preview = document.getElementById('msgAttachmentPreview');
+    preview.innerHTML = `<div class="send-attachment"><span>${escapeHtml(file.name)}</span><span class="remove" onclick="clearAttachment()">&times;</span></div>`;
+  };
+  reader.readAsDataURL(file);
+  input.value = '';
+}
+
+function clearAttachment() {
+  _pendingFile = null;
+  document.getElementById('msgAttachmentPreview').innerHTML = '';
+}
+
+async function sendFromDrawer() {
+  const input = document.getElementById('msgSendInput');
+  const text = input.value.trim();
+  if (!text && !_pendingFile) return;
+  if (!_msgState.userId) return;
+
+  const btn = document.getElementById('msgSendBtn');
+  btn.disabled = true;
+
+  const payload = { to: _msgState.userId };
+  if (text) payload.text = text;
+  if (_pendingFile) {
+    // Determine media type from MIME
+    const mime = _pendingFile.type || '';
+    if (mime.startsWith('image/')) {
+      payload.image = _pendingFile.data;
+    } else if (mime.startsWith('audio/')) {
+      payload.voice = _pendingFile.data;
+    } else if (mime.startsWith('video/')) {
+      payload.video = _pendingFile.data;
+    } else {
+      payload.file = _pendingFile.data;
+      payload.file_name = _pendingFile.name;
+    }
+  }
+
+  try {
+    const resp = await api.sendMessage(payload);
+    if (resp.error) {
+      showToast(resp.error, 'error');
+    } else if (resp.success) {
+      input.value = '';
+      clearAttachment();
+      showToast(i18n.t('send.success'), 'success');
+      // Reload messages to show the sent message
+      setTimeout(() => reloadMessages(), 500);
+    } else {
+      showToast(i18n.t('send.failed'), 'error');
+    }
+  } catch (e) {
+    showToast(e.message, 'error');
+  } finally {
+    btn.disabled = false;
+  }
+}
 
 // Close modals/drawer on Escape
 document.addEventListener('keydown', e => {

--- a/src/weilink/admin/handlers.py
+++ b/src/weilink/admin/handlers.py
@@ -99,6 +99,8 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             self._handle_start_login(body)
         elif path == "/api/set-default":
             self._handle_set_default(body)
+        elif path == "/api/send":
+            self._handle_send(body)
         elif path.endswith("/logout"):
             name = path[len("/api/sessions/") : -len("/logout")]
             self._handle_logout(urllib.parse.unquote(name))
@@ -351,6 +353,49 @@ class AdminRequestHandler(BaseHTTPRequestHandler):
             )
         except ValueError as e:
             self._send_error(404, str(e))
+
+    def _handle_send(self, body: bytes) -> None:
+        """Send a message to a user (text and/or media via base64)."""
+        try:
+            data = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            self._send_error(400, "Invalid JSON body")
+            return
+
+        to_user = data.get("to", "").strip() if isinstance(data.get("to"), str) else ""
+        if not to_user:
+            self._send_error(400, "'to' (user ID) is required")
+            return
+
+        kwargs: dict[str, Any] = {}
+        if data.get("text"):
+            kwargs["text"] = data["text"]
+        for media_key in ("image", "voice", "file", "video"):
+            raw = data.get(media_key)
+            if raw:
+                try:
+                    kwargs[media_key] = base64.b64decode(raw)
+                except Exception:
+                    self._send_error(400, f"Invalid base64 for '{media_key}'")
+                    return
+        if data.get("file_name"):
+            kwargs["file_name"] = data["file_name"]
+
+        if not kwargs:
+            self._send_error(400, "At least 'text' or a media field is required")
+            return
+
+        try:
+            with self._lock:
+                result = self.weilink.send(to_user, **kwargs)
+            self._send_json(
+                {
+                    "success": result.success,
+                    "remaining": result.remaining,
+                }
+            )
+        except Exception as e:
+            self._send_error(400, str(e))
 
     def _handle_get_messages(self, query: dict[str, list[str]]) -> None:
         """Return paginated message history as JSON."""

--- a/src/weilink/admin/locales/en.json
+++ b/src/weilink/admin/locales/en.json
@@ -85,5 +85,11 @@
     "sender_bot": "Bot",
     "download_failed": "Download failed",
     "download": "Download"
+  },
+  "send": {
+    "placeholder": "Type a message...",
+    "send": "Send",
+    "success": "Message sent",
+    "failed": "Send failed"
   }
 }

--- a/src/weilink/admin/locales/zh.json
+++ b/src/weilink/admin/locales/zh.json
@@ -85,5 +85,11 @@
     "sender_bot": "\u673a\u5668\u4eba",
     "download_failed": "\u4e0b\u8f7d\u5931\u8d25",
     "download": "\u4e0b\u8f7d"
+  },
+  "send": {
+    "placeholder": "\u8f93\u5165\u6d88\u606f...",
+    "send": "\u53d1\u9001",
+    "success": "\u6d88\u606f\u5df2\u53d1\u9001",
+    "failed": "\u53d1\u9001\u5931\u8d25"
   }
 }

--- a/src/weilink/cli.py
+++ b/src/weilink/cli.py
@@ -7,7 +7,8 @@ Provides subcommands for bot interaction and server management::
     weilink recv --timeout 5
     weilink send USER_ID --text "hello"
     weilink admin --host 0.0.0.0 -p 8080
-    weilink mcp -t sse -p 8000 --admin-port 8080 -d /data/weilink
+    weilink mcp -t sse -p 8000 -d /data/weilink
+    weilink mcp --no-admin -t stdio
     weilink openapi -p 8000
 """
 
@@ -480,8 +481,8 @@ def _run_mcp(args: argparse.Namespace) -> None:
 
     base_path = Path(args.base_path) if args.base_path else None
 
-    # Optionally start admin panel in the same process.
-    if args.admin_port is not None:
+    # Start admin panel unless explicitly disabled.
+    if not args.no_admin:
         from weilink.server.app import _init_client
 
         _init_client(base_path)
@@ -630,8 +631,8 @@ def _run_openapi(args: argparse.Namespace) -> None:
 
     base_path = Path(args.base_path) if args.base_path else None
 
-    # Optionally start admin panel in the same process.
-    if args.admin_port is not None:
+    # Start admin panel unless explicitly disabled.
+    if not args.no_admin:
         from weilink.server.app import _init_client
 
         _init_client(base_path)
@@ -939,8 +940,14 @@ def main(argv: list[str] | None = None) -> None:
     openapi_parser.add_argument(
         "--admin-port",
         type=int,
-        default=None,
-        help="also start admin panel on this port (same host)",
+        default=8080,
+        help="admin panel port (default: 8080)",
+    )
+    openapi_parser.add_argument(
+        "--no-admin",
+        action="store_true",
+        default=False,
+        help="disable the admin panel",
     )
     openapi_parser.add_argument(
         "--log-level",
@@ -1092,8 +1099,14 @@ def main(argv: list[str] | None = None) -> None:
     mcp_parser.add_argument(
         "--admin-port",
         type=int,
-        default=None,
-        help="also start admin panel on this port (same host)",
+        default=8080,
+        help="admin panel port (default: 8080)",
+    )
+    mcp_parser.add_argument(
+        "--no-admin",
+        action="store_true",
+        default=False,
+        help="disable the admin panel",
     )
     mcp_parser.add_argument(
         "--log-level",

--- a/src/weilink/client.py
+++ b/src/weilink/client.py
@@ -197,6 +197,7 @@ class WeiLink:
         *,
         base_path: str | Path | None = None,
         message_store: bool | str | Path | None = None,
+        fallback_window: float = _FALLBACK_WINDOW,
     ):
         """Initialize the WeiLink client.
 
@@ -211,6 +212,9 @@ class WeiLink:
                 ``None`` (default) disables it.  ``True`` uses
                 ``<base_path>/messages.db``.  A path string or
                 ``Path`` specifies a custom database location.
+            fallback_window: Time window in seconds for Route C
+                degraded SQLite reads when the poll lock is held by
+                another process.  Defaults to 60.
         """
         if token_path is not None:
             self._base_path = Path(token_path).parent
@@ -218,6 +222,7 @@ class WeiLink:
             self._base_path = Path(base_path)
         else:
             self._base_path = _DEFAULT_BASE_PATH
+        self._fallback_window = fallback_window
 
         # Auto-migrate legacy flat default layout into default/ subdir.
         if token_path is None:
@@ -980,7 +985,7 @@ class WeiLink:
         assert session.bot_info is not None
         assert self._message_store is not None
 
-        since_ms = int((time.time() - _FALLBACK_WINDOW) * 1000)
+        since_ms = int((time.time() - self._fallback_window) * 1000)
         messages = self._message_store.query_messages(
             bot_id=session.bot_info.bot_id,
             direction=1,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -446,3 +446,74 @@ class TestAdminMessagesDisabled:
             pytest.fail("Expected HTTPError")
         except urllib.error.HTTPError as e:
             assert e.code == 400
+
+
+class TestAdminSend:
+    """Tests for POST /api/send endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _start_server(self, wl):
+        self.info = wl.start_admin(port=0)
+        self.wl = wl
+        self.base = self.info.url
+        yield
+        wl.stop_admin()
+
+    def _post(self, path, data=None):
+        body = json.dumps(data or {}).encode()
+        req = urllib.request.Request(
+            self.base + path,
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read())
+
+    def test_send_missing_to(self):
+        """POST /api/send without 'to' returns 400."""
+        try:
+            self._post("/api/send", {"text": "hello"})
+            pytest.fail("Expected HTTPError")
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+            body = json.loads(e.read())
+            assert "to" in body["error"].lower()
+
+    def test_send_empty_body(self):
+        """POST /api/send with empty body returns 400."""
+        try:
+            self._post("/api/send", {})
+            pytest.fail("Expected HTTPError")
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+
+    def test_send_no_content(self):
+        """POST /api/send with 'to' but no text/media returns 400."""
+        try:
+            self._post("/api/send", {"to": "user@im.wechat"})
+            pytest.fail("Expected HTTPError")
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+            body = json.loads(e.read())
+            assert "text" in body["error"].lower() or "media" in body["error"].lower()
+
+    def test_send_invalid_base64(self):
+        """POST /api/send with invalid base64 for media returns 400."""
+        try:
+            self._post(
+                "/api/send", {"to": "user@im.wechat", "image": "not-valid-b64!!!"}
+            )
+            pytest.fail("Expected HTTPError")
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+            body = json.loads(e.read())
+            assert "base64" in body["error"].lower()
+
+    def test_send_not_logged_in(self):
+        """POST /api/send when not logged in returns error."""
+        try:
+            self._post("/api/send", {"to": "user@im.wechat", "text": "hello"})
+            pytest.fail("Expected HTTPError")
+        except urllib.error.HTTPError as e:
+            assert e.code == 400

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2001,3 +2001,17 @@ class TestMultiConsumerCorrectness:
         assert "stale@im.wechat" not in session.context_tokens
 
         wl.close()
+
+    def test_fallback_window_configurable(self, tmp_path: Path):
+        """Custom fallback_window is respected by _recv_from_store."""
+        self._setup_base(tmp_path)
+
+        wl_default = WeiLink(base_path=tmp_path, message_store=True)
+        assert wl_default._fallback_window == 60.0
+        wl_default.close()
+
+        wl_custom = WeiLink(
+            base_path=tmp_path, message_store=True, fallback_window=300.0
+        )
+        assert wl_custom._fallback_window == 300.0
+        wl_custom.close()


### PR DESCRIPTION
## Summary

- **hook_poll file locking**: wrap the load-query-save cycle in `FileLock` to prevent concurrent IDE instances (Claude Code, Codex, etc.) from reading the same `last_ts` and missing messages
- **Configurable fallback window**: `WeiLink(fallback_window=N)` lets secondary consumers widen the Route C SQLite read window beyond the default 60s
- **Admin default-on**: MCP and OpenAPI server modes now start the admin panel on port 8080 by default; `--no-admin` opts out
- **Admin send endpoint**: `POST /api/send` accepts text and base64-encoded media (image/voice/file/video); admin panel gets a send UI in the message drawer
- **i18n**: send-related strings added for en/zh locales

## Test plan
- [x] `test_fallback_window_configurable` — verifies default and custom window values
- [x] `TestAdminSend` — 5 tests covering missing `to`, empty body, no content, invalid base64, and not-logged-in error paths
- [x] Full test suite: 345 passed
- [x] `ruff check --fix` + `ruff format` + `ty check` all clean