### PR TITLE
feat: align protocol with official Tencent SDK

### DIFF
--- a/src/weilink/_cdn.py
+++ b/src/weilink/_cdn.py
@@ -58,12 +58,17 @@ def _decode_aes_key(aes_key: str) -> bytes:
     return base64.b64decode(aes_key)
 
 
-def download_media(encrypt_query_param: str, aes_key: str) -> bytes:
+def download_media(
+    encrypt_query_param: str,
+    aes_key: str,
+    full_url: str = "",
+) -> bytes:
     """Download and decrypt a media file from CDN.
 
     Args:
         encrypt_query_param: CDN download query parameter.
         aes_key: AES key string (hex or base64).
+        full_url: Direct CDN URL (when provided, bypasses URL construction).
 
     Returns:
         Decrypted file bytes.
@@ -73,7 +78,11 @@ def download_media(encrypt_query_param: str, aes_key: str) -> bytes:
     """
     key = _decode_aes_key(aes_key)
 
-    url = f"{CDN_BASE}/download?encrypted_query_param={urllib.parse.quote(encrypt_query_param, safe=_URI_SAFE)}"
+    if full_url:
+        url = full_url
+        logger.debug("CDN download using full_url: %s", url)
+    else:
+        url = f"{CDN_BASE}/download?encrypted_query_param={urllib.parse.quote(encrypt_query_param, safe=_URI_SAFE)}"
     req = urllib.request.Request(url, method="GET")
 
     with urllib.request.urlopen(req, timeout=60) as resp:
@@ -131,17 +140,25 @@ def upload_media(
     )
     logger.debug("getuploadurl response: %s", url_resp)
     upload_param = url_resp.get("upload_param", "")
-    if not upload_param:
-        raise RuntimeError(f"No upload_param in response: {url_resp}")
+    upload_full_url = url_resp.get("upload_full_url", "")
+    if upload_full_url:
+        logger.info("Server returned upload_full_url, using direct URL")
+    if not upload_param and not upload_full_url:
+        raise RuntimeError(
+            f"No upload_param or upload_full_url in response: {url_resp}"
+        )
 
     # Encrypt and upload to CDN
     encrypted = aes_ecb_encrypt(file_data, aes_key)
 
-    upload_url = (
-        f"{CDN_BASE}/upload"
-        f"?encrypted_query_param={urllib.parse.quote(upload_param, safe=_URI_SAFE)}"
-        f"&filekey={urllib.parse.quote(filekey, safe=_URI_SAFE)}"
-    )
+    if upload_full_url:
+        upload_url = upload_full_url
+    else:
+        upload_url = (
+            f"{CDN_BASE}/upload"
+            f"?encrypted_query_param={urllib.parse.quote(upload_param, safe=_URI_SAFE)}"
+            f"&filekey={urllib.parse.quote(filekey, safe=_URI_SAFE)}"
+        )
     logger.debug("CDN upload: url=%s ciphertext=%d bytes", upload_url, len(encrypted))
     req = urllib.request.Request(
         upload_url,

--- a/src/weilink/_protocol.py
+++ b/src/weilink/_protocol.py
@@ -73,12 +73,32 @@ def _random_uin() -> str:
     return base64.b64encode(str(val).encode()).decode()
 
 
+def _encode_client_version(version: str) -> str:
+    """Encode a version string as a uint32 in 0x00MMNNPP format.
+
+    Args:
+        version: Dot-separated version string (e.g. "1.0.2").
+
+    Returns:
+        Decimal string of the encoded uint32 (e.g. "65538").
+    """
+    parts = [int(p) for p in version.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    return str((parts[0] << 16) | (parts[1] << 8) | parts[2])
+
+
+_CLIENT_VERSION = _encode_client_version(CHANNEL_VERSION)
+
+
 def _make_headers(token: str | None = None) -> dict[str, str]:
     """Build common iLink request headers."""
     headers: dict[str, str] = {
         "Content-Type": "application/json",
         "AuthorizationType": "ilink_bot_token",
         "X-WECHAT-UIN": _random_uin(),
+        "iLink-App-Id": "bot",
+        "iLink-App-ClientVersion": _CLIENT_VERSION,
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
@@ -135,7 +155,12 @@ def post(
     errcode = result.get("errcode")
 
     if errcode == SESSION_EXPIRED:
-        logger.warning("Session expired on %s (ret=%s)", endpoint, ret)
+        logger.warning(
+            "Session expired on %s (ret=%s, full_resp=%s)",
+            endpoint,
+            ret,
+            str(result)[:500],
+        )
         raise SessionExpiredError(
             ret=ret, errcode=errcode, errmsg=result.get("errmsg", "session expired")
         )
@@ -185,7 +210,14 @@ def get(
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            result: dict[str, Any] = json.loads(resp.read())
+            raw = resp.read()
+            result: dict[str, Any] = json.loads(raw)
+            logger.debug(
+                "GET %s -> HTTP %s, resp_len=%d",
+                endpoint,
+                resp.status,
+                len(raw),
+            )
     except urllib.error.URLError as e:
         raise ILinkError(ret=-1, errmsg=str(e)) from e
 
@@ -212,7 +244,6 @@ def poll_qr_status(qrcode: str, base_url: str = BASE_URL) -> dict[str, Any]:
         params={"qrcode": qrcode},
         base_url=base_url,
         timeout=40.0,
-        extra_headers={"iLink-App-ClientVersion": "1"},
     )
 
 
@@ -321,7 +352,9 @@ def get_config(
     }
     if context_token:
         body["context_token"] = context_token
-    return post(EP_GET_CONFIG, body, token, base_url, timeout=10.0)
+    result = post(EP_GET_CONFIG, body, token, base_url, timeout=10.0)
+    logger.debug("get_config response keys: %s", list(result.keys()))
+    return result
 
 
 def send_typing(

--- a/src/weilink/client.py
+++ b/src/weilink/client.py
@@ -833,8 +833,12 @@ class WeiLink:
                 continue
 
             status = status_resp.get("status", "")
+            logger.debug("QR poll status=%s, keys=%s", status, list(status_resp.keys()))
 
             if status == "confirmed":
+                logger.debug(
+                    "QR confirmed, response keys: %s", list(status_resp.keys())
+                )
                 bot_token = status_resp.get("bot_token", "")
                 base_url = status_resp.get("baseurl", proto.BASE_URL)
                 bot_id = status_resp.get("ilink_bot_id", "")
@@ -867,6 +871,12 @@ class WeiLink:
 
             # "wait" = server says no scan yet; any other unknown status
             # is treated the same — keep polling.
+            if status not in ("wait", ""):
+                logger.info(
+                    "QR poll unknown status=%r, full_resp=%s",
+                    status,
+                    str(status_resp)[:500],
+                )
             print(".", end="", flush=True)
 
         raise proto.ILinkError(ret=-1, errmsg="QR code login timed out (5 min)")
@@ -1414,12 +1424,14 @@ class WeiLink:
         from weilink._cdn import download_media
 
         media = self._get_media_info(msg)
-        if not media or not media.encrypt_query_param:
+        if not media or (not media.encrypt_query_param and not media.full_url):
             raise ValueError(
                 f"Message has no downloadable media (type={msg.msg_type.name})"
             )
 
-        return download_media(media.encrypt_query_param, media.aes_key)
+        return download_media(
+            media.encrypt_query_param, media.aes_key, full_url=media.full_url
+        )
 
     def upload(
         self,
@@ -1596,8 +1608,14 @@ class WeiLink:
         while not self._dispatcher_stop.is_set():
             try:
                 messages = self._recv_direct(timeout=poll_timeout)
-            except proto.SessionExpiredError:
-                logger.error("Session expired, dispatcher stopping")
+            except proto.SessionExpiredError as e:
+                logger.error(
+                    "Session expired, dispatcher stopping "
+                    "(ret=%s, errcode=%s, errmsg=%s)",
+                    e.ret,
+                    e.errcode,
+                    e.errmsg,
+                )
                 break
             except RuntimeError:
                 # Not logged in yet — wait briefly and retry
@@ -1766,10 +1784,16 @@ class WeiLink:
     @staticmethod
     def _parse_media_info(raw: dict[str, Any]) -> MediaInfo:
         """Parse a CDN media reference from a raw dict."""
+        full_url = raw.get("full_url", "")
+        if full_url:
+            logger.info(
+                "Media has full_url from server (bypasses CDN URL construction)"
+            )
         return MediaInfo(
             encrypt_query_param=raw.get("encrypt_query_param", ""),
             aes_key=raw.get("aes_key", ""),
             encrypt_type=raw.get("encrypt_type", 0),
+            full_url=full_url,
         )
 
     @classmethod

--- a/src/weilink/models.py
+++ b/src/weilink/models.py
@@ -107,11 +107,14 @@ class MediaInfo:
         encrypt_query_param: CDN download query parameter.
         aes_key: AES-128-ECB key (hex or base64 encoded).
         encrypt_type: Encryption type identifier (typically 1).
+        full_url: Direct CDN URL (when provided by server, bypasses
+            URL construction from encrypt_query_param).
     """
 
     encrypt_query_param: str = ""
     aes_key: str = ""
     encrypt_type: int = 0
+    full_url: str = ""
 
 
 @dataclass(frozen=True)

--- a/tests/test_cdn.py
+++ b/tests/test_cdn.py
@@ -93,3 +93,24 @@ class TestUploadedMedia:
         assert um.filekey == "abc123"
         assert um.file_size == 100
         assert um.media_type == UploadMediaType.IMAGE
+
+
+class TestMediaInfoFullUrl:
+    """Tests for MediaInfo.full_url field."""
+
+    def test_default_empty(self) -> None:
+        from weilink.models import MediaInfo
+
+        mi = MediaInfo()
+        assert mi.full_url == ""
+
+    def test_with_full_url(self) -> None:
+        from weilink.models import MediaInfo
+
+        mi = MediaInfo(
+            encrypt_query_param="param",
+            aes_key="0" * 32,
+            full_url="https://cdn.example.com/download?id=123",
+        )
+        assert mi.full_url == "https://cdn.example.com/download?id=123"
+        assert mi.encrypt_query_param == "param"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -10,6 +10,8 @@ from weilink._protocol import (
     EP_QR_CODE,
     EP_SEND_MESSAGE,
     SESSION_EXPIRED,
+    _CLIENT_VERSION,
+    _encode_client_version,
     _make_headers,
     _random_uin,
 )
@@ -41,6 +43,29 @@ class TestMakeHeaders:
         headers = _make_headers(token="my_token")
         assert headers["Authorization"] == "Bearer my_token"
         assert headers["Content-Type"] == "application/json"
+
+    def test_ilink_app_id(self):
+        headers = _make_headers()
+        assert headers["iLink-App-Id"] == "bot"
+
+    def test_ilink_app_client_version(self):
+        headers = _make_headers()
+        assert headers["iLink-App-ClientVersion"] == _CLIENT_VERSION
+        # 1.0.2 → 0x00010002 = 65538
+        assert headers["iLink-App-ClientVersion"] == "65538"
+
+
+class TestEncodeClientVersion:
+    def test_1_0_2(self):
+        assert _encode_client_version("1.0.2") == "65538"
+
+    def test_2_1_6(self):
+        # 0x00020106 = 131334
+        assert _encode_client_version("2.1.6") == "131334"
+
+    def test_short_version(self):
+        # "1.0" → 0x00010000 = 65536
+        assert _encode_client_version("1.0") == "65536"
 
 
 class TestConstants:


### PR DESCRIPTION
## Summary

Aligns weilink's protocol implementation with changes discovered in the official Tencent SDK (`@tencent-weixin/openclaw-weixin` v2.1.6):

- **Request headers**: Add `iLink-App-Id: bot` and `iLink-App-ClientVersion: 65538` (uint32 `0x00MMNNPP` encoding of `1.0.2`) to all API requests
- **CDN upload**: Support `upload_full_url` from `getuploadurl` response — use direct URL when server provides one, fall back to `upload_param` construction
- **CDN download**: Add `full_url` field to `MediaInfo` for direct CDN downloads when server provides a complete URL
- **Investigation logging**: Enhanced DEBUG/INFO logging for QR login statuses, session expiry details, `get_config` response, and new CDN fields — prepares for Phase 2 work on `scaned_but_redirect` (#19) and session expiry behavior (#20)

Closes #16, closes #17, closes #18

## Test plan
- [x] New tests for `_make_headers` (iLink-App-Id, iLink-App-ClientVersion)
- [x] New tests for `_encode_client_version` (1.0.2, 2.1.6, short versions)
- [x] New tests for `MediaInfo.full_url` field
- [x] Full test suite: 352 passed
- [x] `ruff check --fix` + `ruff format` + `ty check` all clean